### PR TITLE
Fix no response unhandled-input bug in example

### DIFF
--- a/examples/portraits_balloon/balloon.gd
+++ b/examples/portraits_balloon/balloon.gd
@@ -190,6 +190,8 @@ func _on_response_gui_input(event: InputEvent, item: Control) -> void:
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == 1:
 		next(dialogue_line.responses[item.get_index()].next_id)
 	elif event.is_action_pressed("ui_accept") and item in get_responses():
+		# When there are no response options
+		get_viewport().set_input_as_handled()
 		next(dialogue_line.responses[item.get_index()].next_id)
 
 


### PR DESCRIPTION
Dialogue choices without responses trigger same bug as the balloons. Bug is fixed by setting the input as handled.